### PR TITLE
Fixes AOT compilation failure

### DIFF
--- a/src/ngx-smart-modal/src/components/ngx-smart-modal.component.ts
+++ b/src/ngx-smart-modal/src/components/ngx-smart-modal.component.ts
@@ -228,7 +228,7 @@ export class NgxSmartModalComponent implements OnInit, OnDestroy {
   }
 
   @HostListener('window:resize')
-  private targetPlacement() {
+  public targetPlacement() {
     if (!this.nsmDialog || !this.nsmContent || !this.nsmOverlay || !this.target) {
       return;
     }


### PR DESCRIPTION
When building the project with AOT compiler, it will complain about all non-public properties and methods accessible from the view layer, like data bindings and events handlers, and compilation will fail. More details here - https://github.com/angular/angular-cli/issues/11398#issuecomment-401027357